### PR TITLE
chore: Update ci.yml and Dockerfile-faas for Docker image build and push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
         tags:
             - 'v*.*.*'
     workflow_dispatch:        
-
+env:
+  IMAGE_NAME: index.docker.io/metacall/faas
 jobs:
     ci:
         runs-on: ubuntu-latest
@@ -55,9 +56,30 @@ jobs:
                   TEST_FAAS_STARTUP_DEPLOY=true TEST_FAAS_DEPENDENCY_DEPLOY=true NODE_ENVIRONMENT=deployment docker compose up --exit-code-from test
                   docker compose down
 
-            - name: Publish
+            - name: Publish npm package
               uses: JS-DevTools/npm-publish@v3
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   access: 'public'
                   token: ${{ secrets.NPM_AUTH_TOKEN }}
+
+
+            # Build and push the docker image to DockerHub
+            - name: Set up Docker Buildx #  to be able to build multi-platform images, export cache, etc.
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: docker/setup-buildx-action@v1
+
+            - name: Login to DockerHub #  will take care to log in against a Docker registry
+              uses: docker/login-action@v1 
+              if: startsWith(github.ref, 'refs/tags/')
+              with:
+                username: ${{ secrets.DOCKER_HUB_USERNAME }}
+                password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+            - name: Build and push # will build and push the Docker image to the registry
+              uses: docker/build-push-action@v2
+              if: startsWith(github.ref, 'refs/tags/')
+              with:
+                context: .
+                file: ./Dockerfile-faas
+                push: true
+                tags: metacall/faas:latest

--- a/Dockerfile-faas
+++ b/Dockerfile-faas
@@ -1,0 +1,50 @@
+#
+#	MetaCall FaaS Script by Parra Studios
+#	Reimplementation of MetaCall FaaS platform written in TypeScript.
+#
+#	Copyright (C) 2016 - 2024 Vicente Eduardo Ferrer Garcia <vic798@gmail.com>
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		http://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+
+FROM node:20-bookworm-slim AS base
+
+# Image descriptor
+LABEL copyright.name="Vicente Eduardo Ferrer Garcia" \
+	copyright.address="vic798@gmail.com" \
+	maintainer.name="Vicente Eduardo Ferrer Garcia" \
+	maintainer.address="vic798@gmail.com" \
+	vendor="MetaCall Inc." \
+	version="0.1"
+
+WORKDIR /metacall
+
+FROM base AS deps
+
+COPY . .
+
+RUN npm install \
+	&& npm run build
+
+FROM base as faas
+
+RUN apt-get update \
+	&& apt-get install wget ca-certificates git -y --no-install-recommends \
+	&& wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
+
+COPY --from=deps /metacall/node_modules node_modules
+COPY --from=deps /metacall/dist dist
+
+EXPOSE 9000
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
I didn't find a direct way to build and push the faas image only, so I created another docker file for the faas only, we can add a TODO to improve this later.

Please, add the following secrets:

- DOCKER_HUB_USERNAME
- DOCKER_HUB_ACCESS_TOKEN