### PR TITLE
test: replace placeholder TODO test with basic scaffold

### DIFF
--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,7 +1,35 @@
-import { strict as assert } from 'assert';
+/* eslint-disable @typescript-eslint/unbound-method */
 
-describe('test scaffold', () => {
-	it('basic sanity check', () => {
-		assert.equal(1 + 1, 2);
+import * as assert from 'assert';
+import { printVersionAndExit } from '../utils/version';
+
+describe('utils/version', () => {
+	it('prints the package version and exits with code 0', () => {
+		let output = '';
+		let exitCode: number | undefined;
+
+		const originalLog = console.log;
+		const originalExit = process.exit;
+
+		console.log = (message?: unknown): void => {
+			output = String(message);
+		};
+
+		process.exit = ((code?: number): never => {
+			exitCode = code;
+			throw new Error('process.exit');
+		}) as never;
+
+		try {
+			printVersionAndExit();
+		} catch (error) {
+			assert.strictEqual((error as Error).message, 'process.exit');
+		} finally {
+			console.log = originalLog;
+			process.exit = originalExit;
+		}
+
+		assert.strictEqual(exitCode, 0);
+		assert.match(output, /^v\d+\.\d+\.\d+$/);
 	});
 });


### PR DESCRIPTION
This replaces the placeholder TODO test with a minimal scaffold test.
No functional changes; prepares the test suite for future unit tests.
