### PR TITLE
fix: handle errors when printing version

### DIFF
--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,10 +2,18 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 export function printVersionAndExit(): void {
-	const packageJsonPath = join(__dirname, '../../package.json');
-	const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-		version: string;
-	};
-	console.log(`v${packageJson.version}`);
-	process.exit(0);
+	try {
+		const packageJsonPath = join(__dirname, '../../package.json');
+		const packageJson = JSON.parse(
+			readFileSync(packageJsonPath, 'utf8')
+		) as {
+			version: string;
+		};
+
+		console.log(`v${packageJson.version}`);
+		process.exit(0);
+	} catch (error) {
+		console.error('Failed to read package version');
+		process.exit(1);
+	}
 }


### PR DESCRIPTION
This PR improves robustness of the version printing utility.

If reading or parsing package.json fails, the CLI now:
- prints a helpful error message
- exits with a non-zero status code

This prevents unexpected crashes and makes CLI behavior more predictable.
