### PR TITLE
Fix memory leak from orphaned invocations on deployment deletion

### DIFF
--- a/src/controller/call.ts
+++ b/src/controller/call.ts
@@ -49,7 +49,8 @@ export const callFunction = (
 				},
 				reject: (error: string) => {
 					res.status(500).send(error);
-				}
+				},
+				suffix
 			}),
 			name: func,
 			args

--- a/src/controller/delete.ts
+++ b/src/controller/delete.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 import { Applications } from '../app';
 import { appsDirectory } from '../utils/config';
+import { invokeQueue } from '../utils/invoke';
 import { catchAsync } from './catch';
 
 // TODO: Isn't this available inside protocol package? We MUST reuse it
@@ -30,6 +31,12 @@ export const deployDelete = catchAsync(
 				`Oops! It looks like the application '${suffix}' hasn't been deployed yet. Please deploy it before you delete it.`
 			);
 		}
+
+		// Reject pending invocations before killing the process
+		invokeQueue.rejectBySuffix(
+			suffix,
+			`Deployment '${suffix}' was deleted while processing requests`
+		);
 
 		// Retrieve the child process associated with the application and kill it
 		application.kill();

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -79,7 +79,9 @@ export const deployProcess = async (
 				// Get the invocation id in order to retrieve the callbacks
 				// for resolving the call, this deletes the invocation object
 				const invoke = invokeQueue.get(invokeResult.id);
-				invoke.resolve(JSON.stringify(invokeResult.result));
+				if (invoke) {
+					invoke.resolve(JSON.stringify(invokeResult.result));
+				}
 				break;
 			}
 

--- a/src/utils/invoke.ts
+++ b/src/utils/invoke.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 interface Invocation {
 	resolve: (value: string) => void;
 	reject: (reason: string) => void;
+	suffix: string;
 }
 
 class InvokeQueue {
@@ -14,10 +15,19 @@ class InvokeQueue {
 		return id;
 	}
 
-	public get(id: string): Invocation {
+	public get(id: string): Invocation | undefined {
 		const invoke = this.queue[id];
 		delete this.queue[id];
 		return invoke;
+	}
+
+	public rejectBySuffix(suffix: string, reason: string): void {
+		Object.entries(this.queue).forEach(([id, invoke]) => {
+			if (invoke.suffix === suffix) {
+				invoke.reject(reason);
+				delete this.queue[id];
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
## Problem
When a deployment is deleted, pending invocations in the global queue are not cleaned up. This causes:
- Memory leak as orphaned invocations remain in the queue indefinitely
- Potential crashes when workers try to resolve invocations from deleted deployments

## Solution
- Track deployment ownership by adding `suffix` field to invocations
- Clean up deployment-specific invocations before killing worker process
- Handle race conditions with safe null checks

## Testing
- All existing tests pass
- No ESLint errors or warnings