### PR TITLE
fix: prevent old env variables from persisting during deployment

### DIFF
--- a/src/controller/deploy.ts
+++ b/src/controller/deploy.ts
@@ -51,12 +51,10 @@ export const deploy = catchAsync(
 				.map(([key, value]) => `${key}=${value}`)
 				.join('\n');
 
-			fs.appendFileSync(envFilePath, envFileContent, 'utf-8');
-
+			fs.writeFileSync(envFilePath, envFileContent, 'utf-8');
 			await installDependencies(resource);
 
 			await deployProcess(resource, env);
-
 			return res.status(200).json({
 				prefix: hostname(),
 				suffix: resource?.id,


### PR DESCRIPTION
Currently, the .env file is written using fs.appendFileSync. This causes
environment variables from previous deployments to remain in the file.
As a result, outdated values may persist and override the new configuration.

For example:

Old .env
PORT=3000

New deployment
PORT=8080

With appendFileSync the file becomes:

PORT=3000
PORT=8080

This PR replaces appendFileSync with writeFileSync so the .env file is
overwritten instead of appended. This ensures that only the latest
environment variables are present after deployment.