### PR TITLE
fix(call): prevent `callFunction` crash when request body is missing

### DIFF
--- a/src/controller/call.ts
+++ b/src/controller/call.ts
@@ -26,7 +26,8 @@ export const callFunction = (
 	}
 
 	const { suffix, func } = req.params;
-	const args = Object.values(req.body);
+	const args =
+		req.body && typeof req.body === 'object' ? Object.values(req.body) : [];
 	const application = Applications[suffix];
 
 	// Check if the application exists and it is running

--- a/src/test/controller.call.test.ts
+++ b/src/test/controller.call.test.ts
@@ -1,0 +1,135 @@
+import { strict as assert } from 'assert';
+import { ChildProcess } from 'child_process';
+import { NextFunction, Request, Response } from 'express';
+import { Application, Applications } from '../app';
+import { callFunction } from '../controller/call';
+import { invokeQueue } from '../utils/invoke';
+import { WorkerMessageType } from '../worker/protocol';
+
+interface SentMessage {
+	type: WorkerMessageType;
+	data: {
+		id: string;
+		name: string;
+		args: unknown[];
+	};
+}
+
+function createResponse(): Response {
+	return {
+		status(_code: number) {
+			return this;
+		},
+		send(_body?: unknown) {
+			return this;
+		}
+	} as unknown as Response;
+}
+
+describe('Fix: callFunction Request Body Handling', function () {
+	const suffix = 'issue-11-app';
+	const originalPush = invokeQueue.push.bind(invokeQueue);
+
+	afterEach(() => {
+		delete Applications[suffix];
+		invokeQueue.push = originalPush;
+	});
+
+	it('should enqueue an empty argument list when req.body is undefined', () => {
+		let sentMessage: SentMessage | undefined;
+		invokeQueue.push = () => 'invoke-id';
+		Applications[suffix] = {
+			proc: {
+				send: (message: SentMessage) => {
+					sentMessage = message;
+					return true;
+				}
+			} as unknown as ChildProcess
+		} as Application;
+
+		const req = {
+			params: { suffix, func: 'sum' },
+			body: undefined
+		} as unknown as Request;
+
+		assert.doesNotThrow(() => {
+			callFunction(
+				req,
+				createResponse(),
+				(() => undefined) as NextFunction
+			);
+		});
+		assert.deepStrictEqual(sentMessage?.data.args, []);
+		assert.strictEqual(sentMessage?.data.name, 'sum');
+		assert.strictEqual(sentMessage?.type, WorkerMessageType.Invoke);
+	});
+
+	it('should enqueue an empty argument list when req.body is null', () => {
+		let sentMessage: SentMessage | undefined;
+		invokeQueue.push = () => 'invoke-id';
+		Applications[suffix] = {
+			proc: {
+				send: (message: SentMessage) => {
+					sentMessage = message;
+					return true;
+				}
+			} as unknown as ChildProcess
+		} as Application;
+
+		const req = {
+			params: { suffix, func: 'sum' },
+			body: null
+		} as unknown as Request;
+
+		assert.doesNotThrow(() => {
+			callFunction(
+				req,
+				createResponse(),
+				(() => undefined) as NextFunction
+			);
+		});
+		assert.deepStrictEqual(sentMessage?.data.args, []);
+	});
+
+	it('should preserve object values as invocation arguments', () => {
+		let sentMessage: SentMessage | undefined;
+		invokeQueue.push = () => 'invoke-id';
+		Applications[suffix] = {
+			proc: {
+				send: (message: SentMessage) => {
+					sentMessage = message;
+					return true;
+				}
+			} as unknown as ChildProcess
+		} as Application;
+
+		const req = {
+			params: { suffix, func: 'sum' },
+			body: { first: 1, second: 2, label: 'three' }
+		} as unknown as Request;
+
+		callFunction(req, createResponse(), (() => undefined) as NextFunction);
+		assert.deepStrictEqual(sentMessage?.data.args, [1, 2, 'three']);
+	});
+
+	it('should ignore primitive request bodies instead of coercing them', () => {
+		let sentMessage: SentMessage | undefined;
+		invokeQueue.push = () => 'invoke-id';
+		Applications[suffix] = {
+			proc: {
+				send: (message: SentMessage) => {
+					sentMessage = message;
+					return true;
+				}
+			} as unknown as ChildProcess
+		} as Application;
+
+		const req = {
+			params: { suffix, func: 'sum' },
+			body: 'text body'
+		} as unknown as Request;
+
+		callFunction(req, createResponse(), (() => undefined) as NextFunction);
+		assert.deepStrictEqual(sentMessage?.data.args, []);
+	});
+});


### PR DESCRIPTION
## Summary
This PR fixes  by hardening `callFunction` against missing or invalid request bodies.

Previously, the route could synchronously throw when `req.body` was `undefined` or `null`, because `Object.values(req.body)` was evaluated without a guard. This commonly affects `GET` requests and requests where Express does not populate the body.

The fix safely extracts arguments only when `req.body` is an object:

<img width="1576" height="434" alt="image" src="https://github.com/user-attachments/assets/40875b9d-64e3-4844-9d23-f7c3245a0d6b" />

This preserves normal invocation behavior for object payloads while avoiding crashes for empty, null, or primitive bodies.

## Problem statement
`callFunction` is exposed through both `GET` and `POST` routes. In normal `GET` requests, or in requests where Express does not parse a body, `req.body` can be `undefined`.

The previous implementation effectively relied on:

```ts
Object.values(req.body)
```

That throws `TypeError: Cannot convert undefined or null to object` when `req.body` is missing, so the route fails before the function invocation is sent to the worker.

## Related issue
- Testing Requirement: added focused controller tests covering `undefined`, `null`, object, and primitive request bodies

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## How to test
1. Checkout the branch with this change.
2. Run `cd faas && npm test`.
3. Verify the `Fix: callFunction Request Body Handling` suite passes.
4. Optionally call the route without a body and confirm it no longer crashes before dispatching the invocation.

## Checklist
- [x] I have read the contributing guidelines
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I updated documentation if necessary


## Release notes
Fixed `callFunction` so requests without a parsed body no longer crash the FaaS route.



