### PR TITLE
fix(package): avoid double-response on async upload cleanup errors

### DIFF
--- a/src/controller/package.ts
+++ b/src/controller/package.ts
@@ -43,12 +43,46 @@ const getUploadError = (
 	return new AppError(appError.message, appError.code);
 };
 
+interface PackageUploadState {
+	requestSettled: boolean;
+}
+
+export const handlePackageUploadError = (
+	req: Pick<Request, 'unpipe'>,
+	res: Pick<Response, 'headersSent'>,
+	bb: NodeJS.WritableStream,
+	next: NextFunction,
+	state: PackageUploadState,
+	error: AppError,
+	log: (message: string, error: AppError) => void = (
+		message: string,
+		loggedError: AppError
+	) => {
+		console.error(message, loggedError);
+	}
+): void => {
+	if (state.requestSettled || res.headersSent) {
+		log(
+			'Ignoring package upload async error after response was already settled',
+			error
+		);
+		return;
+	}
+
+	state.requestSettled = true;
+	req.unpipe(bb);
+	next(error);
+};
+
 export const packageUpload = (
 	req: Request,
 	res: Response,
 	next: NextFunction
 ): void => {
 	const bb = busboy({ headers: req.headers });
+	const state: PackageUploadState = {
+		requestSettled: false
+	};
 	const resource: Resource = {
 		id: '',
 		type: '',
@@ -63,8 +97,7 @@ export const packageUpload = (
 	});
 
 	const errorHandler = (error: AppError) => {
-		req.unpipe(bb);
-		next(error);
+		handlePackageUploadError(req, res, bb, next, state, error);
 	};
 
 	const eventHandler = <T>(type: keyof busboy.BusboyEvents, listener: T) => {
@@ -228,6 +261,7 @@ export const packageUpload = (
 			unzipAndResolve()
 				.then(() => {
 					resourceResolve(resource);
+					state.requestSettled = true;
 					res.status(201).json({
 						id: resource.id
 					});

--- a/src/test/controller.package.test.ts
+++ b/src/test/controller.package.test.ts
@@ -1,0 +1,90 @@
+import { strict as assert } from 'assert';
+import { NextFunction, Request, Response } from 'express';
+import AppError from '../utils/appError';
+import { handlePackageUploadError } from '../controller/package';
+
+describe('Fix: packageUpload Async Cleanup Error Handling', function () {
+	it('should unpipe and forward the error before a response is sent', () => {
+		let unpipeCalls = 0;
+		let nextError: AppError | undefined;
+		const req = {
+			unpipe(_stream: NodeJS.WritableStream) {
+				unpipeCalls += 1;
+				return this;
+			}
+		} as unknown as Pick<Request, 'unpipe'>;
+		const res = {
+			headersSent: false
+		} as Pick<Response, 'headersSent'>;
+		const bb = {} as NodeJS.WritableStream;
+		const state = { requestSettled: false };
+		const error = new AppError('upload failed', 500);
+		const next = ((err?: unknown) => {
+			nextError = err as AppError;
+		}) as NextFunction;
+
+		handlePackageUploadError(req, res, bb, next, state, error);
+
+		assert.strictEqual(unpipeCalls, 1);
+		assert.strictEqual(nextError, error);
+		assert.strictEqual(state.requestSettled, true);
+	});
+
+	it('should ignore async cleanup errors after headers were already sent', () => {
+		let unpipeCalls = 0;
+		let nextCalls = 0;
+		const logs: string[] = [];
+		const req = {
+			unpipe(_stream: NodeJS.WritableStream) {
+				unpipeCalls += 1;
+				return this;
+			}
+		} as unknown as Pick<Request, 'unpipe'>;
+		const res = {
+			headersSent: true
+		} as Pick<Response, 'headersSent'>;
+		const bb = {} as NodeJS.WritableStream;
+		const state = { requestSettled: true };
+		const error = new AppError('cleanup failed', 500);
+		const next = (() => {
+			nextCalls += 1;
+		}) as NextFunction;
+
+		handlePackageUploadError(req, res, bb, next, state, error, message => {
+			logs.push(message);
+		});
+
+		assert.strictEqual(unpipeCalls, 0);
+		assert.strictEqual(nextCalls, 0);
+		assert.strictEqual(logs.length, 1);
+		assert.match(logs[0], /Ignoring package upload async error/);
+	});
+
+	it('should ignore repeated errors once the request is already settled', () => {
+		let unpipeCalls = 0;
+		let nextCalls = 0;
+		const req = {
+			unpipe(_stream: NodeJS.WritableStream) {
+				unpipeCalls += 1;
+				return this;
+			}
+		} as unknown as Pick<Request, 'unpipe'>;
+		const res = {
+			headersSent: false
+		} as Pick<Response, 'headersSent'>;
+		const bb = {} as NodeJS.WritableStream;
+		const state = { requestSettled: true };
+		const error = new AppError('late cleanup failure', 500);
+		const next = (() => {
+			nextCalls += 1;
+		}) as NextFunction;
+
+		handlePackageUploadError(req, res, bb, next, state, error, () => {
+			return;
+		});
+
+		assert.strictEqual(unpipeCalls, 0);
+		assert.strictEqual(nextCalls, 0);
+		assert.strictEqual(state.requestSettled, true);
+	});
+});


### PR DESCRIPTION
## Summary
This PR fixes a package upload error-handling bug in `src/controller/package.ts`.

During package extraction and cleanup, temporary blob deletion can fail asynchronously. Before this fix, those late cleanup errors still flowed into `next(error)` even after the upload had already returned `201 Created`. That creates a second Express error path after the response is already committed, which can make the server try to send another response for the same request.

The fix adds a small response-settlement guard so asynchronous cleanup failures are only forwarded while the request is still active. If the response has already been sent, the error is safely ignored and logged instead of attempting a second response.

## Problem statement
The package upload route performs asynchronous cleanup after the uploaded zip has been written and extracted. One of those cleanup steps deletes the temporary blob from disk.

If that cleanup fails after the success response has already been sent, the previous code still called the shared error handler. In Express, that means trying to enter the error middleware after headers are already sent, which leads to the classic double-response failure:

the server tries to handle the same request twice

In short, a non-critical cleanup failure could escalate into a runtime response-state error.

## Related issue
- Testing Requirement: added focused controller tests covering pre-response forwarding and post-response async cleanup suppression

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## How to test
1. Checkout the branch with this change.
2. Run `cd faas && npm test`.
3. Verify the `Fix: packageUpload Async Cleanup Error Handling` suite passes.
4. Confirm async cleanup errors after a completed upload do not trigger a second Express error response.

## Checklist
- [x] I have read the contributing guidelines
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I updated documentation if necessary

Note:
The guard is intentionally narrow. It does not hide upload failures that happen before the response is sent. It only prevents late asynchronous cleanup errors from re-entering Express after the request has already been settled.

## Release notes
Fixed package upload so late async cleanup failures no longer trigger a second response attempt after success.
