### PR TITLE
fix: prevent server crash on bad function call arguments (closes #64)

### DIFF
--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -47,6 +47,7 @@ export const deployProcess = async (
 	// Wait for load result
 	let deployResolve: (value: void) => void;
 	let deployReject: (reason: Error) => void;
+	let isDeploySettled = false;
 
 	const promise = new Promise<void>((resolve, reject) => {
 		deployResolve = resolve;
@@ -54,7 +55,10 @@ export const deployProcess = async (
 	});
 
 	proc.on('error', (err: Error) => {
-		deployReject(err);
+		if (!isDeploySettled) {
+			isDeploySettled = true;
+			deployReject(err);
+		}
 	});
 
 	proc.on('message', (payload: WorkerMessageUnknown) => {
@@ -66,6 +70,7 @@ export const deployProcess = async (
 
 				application.proc = proc;
 				application.deployment = deployment;
+				isDeploySettled = true;
 				deployResolve();
 				break;
 			}
@@ -79,7 +84,23 @@ export const deployProcess = async (
 				// Get the invocation id in order to retrieve the callbacks
 				// for resolving the call, this deletes the invocation object
 				const invoke = invokeQueue.get(invokeResult.id);
-				invoke.resolve(JSON.stringify(invokeResult.result));
+				if (invoke) {
+					invoke.resolve(JSON.stringify(invokeResult.result));
+				}
+				break;
+			}
+
+			case WorkerMessageType.InvokeError: {
+				const invokeError = payload.data as {
+					id: string;
+					error: string;
+				};
+
+				// Reject the pending HTTP request with the error from the worker
+				const invoke = invokeQueue.get(invokeError.id);
+				if (invoke) {
+					invoke.reject(invokeError.error);
+				}
 				break;
 			}
 
@@ -89,21 +110,27 @@ export const deployProcess = async (
 	});
 
 	proc.on('exit', code => {
-		// The application may have been ended unexpectedly,
-		// probably segmentation fault (exit code 139 in Linux)
-		deployReject(
-			new Error(
-				`Deployment '${resource.id}' process exited with code: ${
-					code || 'unknown'
-				}`
-			)
-		);
+		// Reject any in-flight function calls that are still waiting for a
+		// response. This prevents HTTP requests from hanging indefinitely
+		// when the worker process exits unexpectedly (e.g. segmentation fault,
+		// native crash from a bad argument passed to a MetaCall function).
+		const errorMessage = `Worker process for deployment '${resource.id}' exited with code: ${code ?? 'unknown'}`;
 
-		// TODO: How to implement the exit properly? We cannot reject easily
-		// the promise from the call if the process exits during the call.
-		// Also if exits during the call it will try to call deployReject
-		// which is completely out of scope and the promise was fullfilled already
+		for (const id of invokeQueue.pendingIds()) {
+			const invoke = invokeQueue.get(id);
+			if (invoke) {
+				invoke.reject(errorMessage);
+			}
+		}
+
+		// Only reject the deploy promise if deployment hadn't completed yet
+		// (i.e. the process exited before sending MetaData back).
+		if (!isDeploySettled) {
+			isDeploySettled = true;
+			deployReject(new Error(errorMessage));
+		}
 	});
 
 	return promise;
 };
+

--- a/src/utils/invoke.ts
+++ b/src/utils/invoke.ts
@@ -19,6 +19,10 @@ class InvokeQueue {
 		delete this.queue[id];
 		return invoke;
 	}
+
+	public pendingIds(): string[] {
+		return Object.keys(this.queue);
+	}
 }
 
 export const invokeQueue = new InvokeQueue();

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -155,16 +155,16 @@ process.on('message', (payload: WorkerMessageUnknown) => {
 						});
 					}
 				} catch (err) {
-					// We must inform the master about the error or handle it gracefully.
-					// Since there wasn't an explicit InvokeError type, we'll mimic the old
-					// behavior but at least prevent the worker from crashing silently.
+					// Send a dedicated InvokeError message so the master process
+					// can reject the pending HTTP request with a proper error response
+					// instead of crashing or silently hanging.
 					console.error(`Error executing function ${fn.name}:`, err);
 					if (process.send) {
 						process.send({
-							type: WorkerMessageType.InvokeResult,
+							type: WorkerMessageType.InvokeError,
 							data: {
 								id: fn.id,
-								result: { error: String(err) }
+								error: String(err)
 							}
 						});
 					}

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -3,7 +3,8 @@ export enum WorkerMessageType {
 	Load = 'LoadFunctions',
 	MetaData = 'GetApplicationMetadata',
 	Invoke = 'CallFunction',
-	InvokeResult = 'FunctionInvokeResult'
+	InvokeResult = 'FunctionInvokeResult',
+	InvokeError = 'FunctionInvokeError'
 }
 
 export interface WorkerMessage<T> {

--- a/test/test.sh
+++ b/test/test.sh
@@ -148,6 +148,28 @@ function test_python_base_app() {
 	local url=$1
 	[[ $(curl -s $url/number) = 100 ]] || exit 1
 	[[ $(curl -s $url/text) = '"asd"' ]] || exit 1
+
+	# Regression test for issue #64: sending bad args must NOT crash the server.
+	# The function 'number' takes 0 arguments; passing one should return HTTP 500
+	# with an error message, and the server must remain alive afterwards.
+	local bad_status
+	bad_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+		-H "Content-Type: application/json" \
+		-d '{"x":1}' \
+		"$url/number")
+	if [[ "$bad_status" != "500" ]]; then
+		echo "Bad-request test failed: expected HTTP 500, got $bad_status"
+		exit 1
+	fi
+
+	# Server must still be responsive after the bad request
+	local readiness
+	readiness=$(check_readiness)
+	if [[ "$readiness" != "200" ]]; then
+		echo "Server is down after bad request (issue #64 regression): readiness returned $readiness"
+		exit 1
+	fi
+	echo "Bad-request regression test (issue #64) passed."
 }
 
 # Test function for python-dependency-app


### PR DESCRIPTION
## Problem

When a MetaCall function is called with the wrong number of arguments (e.g. `curl ... -X POST --data '1'` against a zero-argument Python function), the native MetaCall runtime throws an exception inside the worker child process. This unhandled error caused the **worker process to exit**, which:

- Left all pending HTTP requests hanging forever (the HTTP client never received a response)
- - Made the FaaS server appear to be down (`metacall-deploy --inspect --dev` would exit)
- - Required a full container restart to recover
Fixes #64.

## Root Cause

The `proc.on('exit')` handler in `src/utils/deploy.ts` had a `// TODO` comment acknowledging it could not properly reject in-flight invocations when the worker exited mid-call. Pending invocations stored in `invokeQueue` were never resolved or rejected, so their HTTP responses were never sent.

Additionally, there was no dedicated error message type for function invocation failures --- the worker reused `InvokeResult` with a `{ error: ... }` field, which the master process always treated as a success by calling `resolve()`.

## Changes

### `src/worker/protocol.ts`
- Add a dedicated `InvokeError` message type to the protocol enum.
### `src/worker/index.ts`
- In the `Invoke` handler catch block, send `InvokeError` (with the stringified error) instead of a fake `InvokeResult` with an embedded `error` field.
### `src/utils/invoke.ts`
- Add a `pendingIds()` method to `InvokeQueue` so callers can enumerate and drain all in-flight invocations.
### `src/utils/deploy.ts`
- Handle the new `InvokeError` message type by calling `invoke.reject()` so the client receives an HTTP 500 with the error message.
- - Fix the `exit` handler: iterate `invokeQueue.pendingIds()` and reject every pending invocation --- resolves the `// TODO` and prevents requests from hanging when the worker crashes.
- - Guard `deployReject`/`deployResolve` with an `isDeploySettled` flag to prevent calling them after the deploy promise has already settled.
- - Add null-guard on `invokeQueue.get()` return values.
### `test/test.sh`
- Add a regression test in `test_python_base_app` that POSTs a spurious argument to the zero-arg `number()` function, asserts HTTP 500 is returned, and confirms readiness still returns 200.
## Before / After

| Scenario | Before | After |
|---|---|---|
| Bad args to function | Worker exits, request hangs, server appears down | HTTP 500 returned, server stays up |
| Worker exits mid-call | Pending requests hang indefinitely | All pending requests get HTTP 500 immediately |
| Deploy promise after exit | `deployReject` called on settled promise (silent error) | Guarded by `isDeploySettled` flag |
