### PR TITLE
feat: add GET /health endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import healthRouter from './routes/health';
 import { callFunction } from './controller/call';
 import { deployDelete } from './controller/delete';
 import { deploy } from './controller/deploy';
@@ -75,6 +76,8 @@ export function initializeAPI(): Express {
 			return res.status(200).json([]);
 		}
 	);
+
+	app.use(healthRouter);
 
 	// For all the additional unimplemented routes
 	app.all('*', (req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,21 @@
+import { Request, Response, Router } from 'express';
+
+const router = Router();
+
+router.get('/health', (_req: Request, res: Response) => {
+	const mem = process.memoryUsage();
+	return res.status(200).json({
+		status: 'ok',
+		version: process.env.npm_package_version ?? 'unknown',
+		uptime: Math.floor(process.uptime()),
+		timestamp: new Date().toISOString(),
+		runtime: 'metacall-faas-local',
+		memory: {
+			heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+			heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
+			rss: Math.round(mem.rss / 1024 / 1024)
+		}
+	});
+});
+
+export default router;


### PR DESCRIPTION
## Summary
Adds a `GET /health` endpoint to the local FaaS server. Returns JSON with service status, version, uptime, timestamp, runtime identifier, and heap/RSS memory usage in MB.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## How to test
1. Checkout the branch
2. Run `npm ci`
3. Run `npm start`
4. In another terminal: `curl http://localhost:9000/health`
5. Verify HTTP 200 with JSON body containing `status`, `version`, `uptime`, `timestamp`, `runtime`, `memory`

## Checklist
- [x] I have read the contributing guidelines
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I updated documentation if necessary

## Notes for reviewers
Registered in `src/api.ts` before the catch-all `app.all('*')` middleware. Router isolated in `src/routes/health.ts`. No new dependencies added.
