### PR TITLE
fix(static): stop static handler after validation failures

### DIFF
--- a/src/controller/static.ts
+++ b/src/controller/static.ts
@@ -8,7 +8,11 @@ import { exists } from '../utils/filesystem';
 import { catchAsync } from './catch';
 
 export const serveStatic = catchAsync(
-	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+	async (
+		req: Request,
+		res: Response,
+		next: NextFunction
+	): Promise<Response | void> => {
 		if (!req.params) {
 			throw new AppError('Invalid API endpoint', 404);
 		}
@@ -18,9 +22,9 @@ export const serveStatic = catchAsync(
 
 		// Check if the application exists and it is running
 		if (!application?.proc) {
-			next(
+			return next(
 				new AppError(
-					`Oops! It looks like the application 'suffix' hasn't been deployed yet. Please deploy it before you can call its functions.`,
+					`Oops! It looks like the application '${suffix}' hasn't been deployed yet. Please deploy it before you can call its functions.`,
 					404
 				)
 			);
@@ -28,13 +32,14 @@ export const serveStatic = catchAsync(
 
 		const filePath = path.join(appsDirectory, suffix, file);
 
-		if (!(await exists(filePath)))
-			next(
+		if (!(await exists(filePath))) {
+			return next(
 				new AppError(
 					'The file you are looking for might not be available or the application may not be deployed.',
 					404
 				)
 			);
+		}
 
 		return res.status(200).sendFile(filePath);
 	}

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,12 +1,17 @@
 import { strict as assert } from 'assert';
 import { ChildProcess, spawn } from 'child_process';
 import { mkdir, rm, writeFile } from 'fs/promises';
+import { createServer, get as httpGet, IncomingMessage } from 'http';
 import { hostname } from 'os';
 import path from 'path';
-import request from 'supertest';
 import { Application, Applications } from '../app';
 import { initializeAPI } from '../api';
 import { appsDirectory } from '../utils/config';
+
+type RouteResponse = {
+	status: number;
+	text: string;
+};
 
 // Helper: build the envStringified object the same way deployProcess does.
 // This is a pure-function extraction of the logic we fixed, so we can unit-test
@@ -21,6 +26,62 @@ function buildEnv(env: Record<string, string>): Record<string, string> {
 		}
 	}
 	return envStringified;
+}
+
+async function getResponse(
+	app: ReturnType<typeof initializeAPI>,
+	routePath: string
+): Promise<RouteResponse> {
+	const server = createServer(app);
+	await new Promise<void>((resolve, reject) => {
+		const onError = (err: Error) => {
+			server.off('error', onError);
+			reject(err);
+		};
+		server.once('error', onError);
+		server.listen(0, '127.0.0.1', () => {
+			server.off('error', onError);
+			resolve();
+		});
+	});
+
+	try {
+		const address = server.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('Failed to bind test server');
+		}
+
+		return await new Promise<RouteResponse>((resolve, reject) => {
+			const req = httpGet(
+				`http://127.0.0.1:${address.port}${routePath}`,
+				(response: IncomingMessage) => {
+					let body = '';
+					response.setEncoding('utf8');
+					response.on('data', (chunk: string) => {
+						body += chunk;
+					});
+					response.on('end', () => {
+						resolve({
+							status: response.statusCode ?? 500,
+							text: body
+						});
+					});
+				}
+			);
+
+			req.on('error', reject);
+		});
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close(err => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				resolve();
+			});
+		});
+	}
 }
 
 // Helper: invoke a function that may be sync or async, just as the worker does.
@@ -279,7 +340,7 @@ describe('Fix: Static Route Early Returns', function () {
 
 	it('should return a 404 with the real suffix when the app is not deployed', async () => {
 		const app = initializeAPI();
-		const response = await request(app).get(routePath);
+		const response = await getResponse(app, routePath);
 
 		assert.strictEqual(response.status, 404);
 		assert.match(
@@ -295,7 +356,7 @@ describe('Fix: Static Route Early Returns', function () {
 		} as Application;
 		await mkdir(appPath, { recursive: true });
 
-		const response = await request(app).get(routePath);
+		const response = await getResponse(app, routePath);
 
 		assert.strictEqual(response.status, 404);
 		assert.strictEqual(
@@ -312,7 +373,7 @@ describe('Fix: Static Route Early Returns', function () {
 		await mkdir(appPath, { recursive: true });
 		await writeFile(filePath, 'hello from static route', 'utf8');
 
-		const response = await request(app).get(routePath);
+		const response = await getResponse(app, routePath);
 
 		assert.strictEqual(response.status, 200);
 		assert.strictEqual(response.text, 'hello from static route');

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,6 +1,12 @@
 import { strict as assert } from 'assert';
 import { ChildProcess, spawn } from 'child_process';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { hostname } from 'os';
 import path from 'path';
+import request from 'supertest';
+import { Application, Applications } from '../app';
+import { initializeAPI } from '../api';
+import { appsDirectory } from '../utils/config';
 
 // Helper: build the envStringified object the same way deployProcess does.
 // This is a pure-function extraction of the logic we fixed, so we can unit-test
@@ -253,5 +259,62 @@ describe('Fix: Asynchronous Function Execution', function () {
 			['world']
 		);
 		assert.strictEqual(r2.result, false);
+	});
+});
+
+// Fix: Static Route Early Returns
+// Ensures validation failures stop request processing before sendFile runs.
+describe('Fix: Static Route Early Returns', function () {
+	const suffix = 'static-app';
+	const host = hostname();
+	const fileName = 'hello.txt';
+	const routePath = `/${host}/${suffix}/v1/static/.metacall/faas/apps/${suffix}/${fileName}`;
+	const appPath = path.join(appsDirectory, suffix);
+	const filePath = path.join(appPath, fileName);
+
+	afterEach(async () => {
+		delete Applications[suffix];
+		await rm(appPath, { recursive: true, force: true });
+	});
+
+	it('should return a 404 with the real suffix when the app is not deployed', async () => {
+		const app = initializeAPI();
+		const response = await request(app).get(routePath);
+
+		assert.strictEqual(response.status, 404);
+		assert.match(
+			response.text,
+			new RegExp(`application '${suffix}' hasn't been deployed yet`)
+		);
+	});
+
+	it('should return a 404 when the static file is missing', async () => {
+		const app = initializeAPI();
+		Applications[suffix] = {
+			proc: {} as ChildProcess
+		} as Application;
+		await mkdir(appPath, { recursive: true });
+
+		const response = await request(app).get(routePath);
+
+		assert.strictEqual(response.status, 404);
+		assert.strictEqual(
+			response.text,
+			'The file you are looking for might not be available or the application may not be deployed.'
+		);
+	});
+
+	it('should serve the requested file when the app is deployed and the file exists', async () => {
+		const app = initializeAPI();
+		Applications[suffix] = {
+			proc: {} as ChildProcess
+		} as Application;
+		await mkdir(appPath, { recursive: true });
+		await writeFile(filePath, 'hello from static route', 'utf8');
+
+		const response = await request(app).get(routePath);
+
+		assert.strictEqual(response.status, 200);
+		assert.strictEqual(response.text, 'hello from static route');
 	});
 });


### PR DESCRIPTION


## Summary
This PR fixes a control-flow bug in `src/controller/static.ts`.

The static handler already forwarded validation failures with `next(...)`, but it did not stop execution. Because of that, the request could still continue to `sendFile(...)` after entering the error path.

This change makes the handler return immediately on validation failure and fixes the undeployed-app message so it shows the real application suffix.

## Problem statement
The static route should do one of two things:
- return an error when the app is not deployed or the file does not exist
- serve the file when validation passes

Before the fix, it could do both paths in the same request because the error branches were missing `return`.

## What changed
- added early returns for undeployed-app validation failures
- added early returns for missing-file validation failures
- corrected the undeployed-app error message to include the actual suffix
- verified route behavior with tests for failure and success paths

## Tests Screensort
<img width="1508" height="618" alt="image" src="https://github.com/user-attachments/assets/3325dd8d-f4c2-41da-b315-d9baf941d12d" />



## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## Checklist
- [x] I have read the contributing guidelines
- [x] I verified the fix with tests
- [x] I verified existing tests still pass
- [ ] I updated documentation if necessary

## Release notes
Fixed the static file route so failed validation exits immediately instead of falling through to `sendFile(...)`.
