### PR TITLE
fix: return `/delete` endpoint response as JSON to match API contract

### DIFF
--- a/src/controller/delete.ts
+++ b/src/controller/delete.ts
@@ -26,7 +26,7 @@ export const deployDelete = catchAsync(
 
 		// Check if the application exists and it is running
 		if (!application?.proc) {
-			return res.send(
+			return res.json(
 				`Oops! It looks like the application '${suffix}' hasn't been deployed yet. Please deploy it before you delete it.`
 			);
 		}
@@ -44,6 +44,6 @@ export const deployDelete = catchAsync(
 		await rm(appLocation, { recursive: true, force: true });
 
 		// Send response based on whether there was an error during deletion
-		return res.send('Deploy Delete Succeed');
+		return res.json('Deploy Delete Succeed');
 	}
 );


### PR DESCRIPTION
## Summary
Changed `res.send(...)` to `res.json(...)` in the `/api/deploy/delete` controller so the response body is valid JSON. The protocol client parses this response with `res.json()`, so the plain-text response caused a `SyntaxError` that the CLI wrongly reported as "Server responded with error code: unknown".


## Related issue
> closes metacall/deploy#255

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## How to test
Steps to reproduce or verify the change locally:
1. Checkout the branch
2. Run `npm ci` (or equivalent)
3. Run `npm test` and any additional verification steps

## Checklist
- [x] I have read the contributing guidelines
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I updated documentation if necessary

## Notes for reviewers
Here is a screenshot after the changes

<img width="761" height="673" alt="image" src="https://github.com/user-attachments/assets/ac980e31-52b4-4c1c-b02f-78456d55ce78" />


## Release notes
Short note for changelog/release, if applicable.
