### PR TITLE
Migrate logs from `logs/app.log` to per deployment log files.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       timeout: 2s
       retries: 30
     volumes:
-      - ./logs:/metacall/logs
+      - ./logs:/root/.metacall/faas/logs
 
   test:
     image: metacall/faas:test

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import { Deployment, MetaCallJSON } from '@metacall/protocol/deployment';
 import { ChildProcess } from 'child_process';
+import { ProcessLogHandle } from './utils/logger';
 
 export interface Resource {
 	id: string;
@@ -14,6 +15,7 @@ export class Application {
 	public resource?: Promise<Resource>;
 	public proc?: ChildProcess;
 	public deployment?: Deployment;
+	public logger?: ProcessLogHandle;
 
 	public kill(): void {
 		this.proc?.kill();

--- a/src/controller/delete.ts
+++ b/src/controller/delete.ts
@@ -34,6 +34,9 @@ export const deployDelete = catchAsync(
 		// Retrieve the child process associated with the application and kill it
 		application.kill();
 
+		// Stop the logger associated with the application
+		await application.logger?.close();
+
 		// Remove the application Applications object
 		delete Applications[suffix];
 

--- a/src/controller/delete.ts
+++ b/src/controller/delete.ts
@@ -4,7 +4,7 @@ import { rm } from 'fs/promises';
 import { join } from 'path';
 
 import { Applications } from '../app';
-import { appsDirectory } from '../utils/config';
+import { appsDirectory, logsDirectory } from '../utils/config';
 import { catchAsync } from './catch';
 
 // TODO: Isn't this available inside protocol package? We MUST reuse it
@@ -40,11 +40,13 @@ export const deployDelete = catchAsync(
 		// Remove the application Applications object
 		delete Applications[suffix];
 
-		// Determine the location of the application
+		// Determine the location of the application and its logs
 		const appLocation = join(appsDirectory, suffix);
+		const logsLocation = join(logsDirectory, suffix);
 
-		// Delete the directory of the application
+		// Delete the directory of the application and its logs
 		await rm(appLocation, { recursive: true, force: true });
+		await rm(logsLocation, { recursive: true, force: true });
 
 		// Send response based on whether there was an error during deletion
 		return res.json('Deploy Delete Succeed');

--- a/src/test/controller.delete.test.ts
+++ b/src/test/controller.delete.test.ts
@@ -187,6 +187,7 @@ describe('deploy delete', () => {
 			'proc.kill',
 			'logger.close',
 			'logger.drained',
+			'fs.rm',
 			'fs.rm'
 		]);
 		assert.strictEqual(Applications[suffix], undefined);

--- a/src/test/controller.delete.test.ts
+++ b/src/test/controller.delete.test.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from 'assert';
+import { ChildProcess } from 'child_process';
+import { NextFunction, Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { Application, Applications, Resource } from '../app';
+import { deployDelete } from '../controller/delete';
+import { IAppError } from '../utils/appError';
+import { appsDirectory } from '../utils/config';
+import { ProcessLogHandle } from '../utils/logger';
+
+interface MockResponse {
+	res: Response;
+	getJSON: () => unknown;
+	getStatusCode: () => number;
+}
+
+type MutableFsPromises = {
+	rm: typeof fs.promises.rm;
+};
+
+const mutableFsPromises = fs.promises as MutableFsPromises;
+const originalRm = mutableFsPromises.rm;
+
+function createMockResponse(): MockResponse {
+	let statusCode = 200;
+	let responseBody: unknown;
+
+	const res = {
+		status(code: number) {
+			statusCode = code;
+			return this;
+		},
+		json(body: unknown) {
+			responseBody = body;
+			return this;
+		},
+		send(body: unknown) {
+			responseBody = body;
+			return this;
+		}
+	} as unknown as Response;
+
+	return {
+		res,
+		getJSON: () => responseBody,
+		getStatusCode: () => statusCode
+	};
+}
+
+async function invokeDeployDelete(req: Partial<Request>): Promise<{
+	err?: IAppError;
+	response: MockResponse;
+}> {
+	const mockRes = createMockResponse();
+	let capturedError: IAppError | undefined;
+
+	const next: NextFunction = (err?: unknown) => {
+		if (err) {
+			capturedError = err as IAppError;
+		}
+	};
+
+	await (
+		deployDelete as unknown as (
+			req: Request,
+			res: Response,
+			next: NextFunction
+		) => Promise<unknown>
+	)(req as Request, mockRes.res, next);
+
+	return { err: capturedError, response: mockRes };
+}
+
+describe('deploy delete', () => {
+	let removedPaths: Array<{ path: string; options?: unknown }>;
+	let rmCallCount: number;
+
+	beforeEach(() => {
+		removedPaths = [];
+		rmCallCount = 0;
+		mutableFsPromises.rm = ((
+			targetPath: fs.PathLike,
+			options?: unknown
+		) => {
+			rmCallCount++;
+			removedPaths.push({ path: String(targetPath), options });
+			return Promise.resolve();
+		}) as typeof fs.promises.rm;
+	});
+
+	afterEach(() => {
+		mutableFsPromises.rm = originalRm;
+		for (const key of Object.keys(Applications)) {
+			delete Applications[key];
+		}
+	});
+
+	it('should return 200 when application is not deployed', async () => {
+		const suffix = 'unstarted-app';
+		const { err, response } = await invokeDeployDelete({
+			body: { suffix }
+		});
+
+		assert.strictEqual(err, undefined);
+		assert.strictEqual(response.getStatusCode(), 200);
+		assert.strictEqual(
+			response.getJSON(),
+			`Oops! It looks like the application '${suffix}' hasn't been deployed yet. Please deploy it before you delete it.`
+		);
+		assert.strictEqual(rmCallCount, 0);
+	});
+
+	it('should return 200 when application has no running process', async () => {
+		const suffix = 'unstarted-app';
+		const app = new Application();
+		app.proc = undefined;
+		Applications[suffix] = app;
+
+		const { err, response } = await invokeDeployDelete({
+			body: { suffix }
+		});
+
+		assert.strictEqual(err, undefined);
+		assert.strictEqual(response.getStatusCode(), 200);
+		assert.strictEqual(
+			response.getJSON(),
+			`Oops! It looks like the application '${suffix}' hasn't been deployed yet. Please deploy it before you delete it.`
+		);
+		assert.strictEqual(rmCallCount, 0);
+	});
+
+	it('should kill the process, drain logger, and delete directory on success', async () => {
+		const suffix = 'lifecycle-app';
+		const events: string[] = [];
+		let resolveDrain: () => void = () => undefined;
+		const drainPromise = new Promise<void>(resolve => {
+			resolveDrain = resolve;
+		});
+
+		const app = new Application();
+		app.proc = {
+			kill: () => {
+				events.push('proc.kill');
+				return true;
+			}
+		} as unknown as ChildProcess;
+		app.resource = Promise.resolve({
+			id: suffix,
+			path: path.join(appsDirectory, suffix),
+			jsons: [],
+			runners: []
+		} as Resource);
+
+		const mockLogger: ProcessLogHandle = {
+			close: () => {
+				events.push('logger.close');
+				return drainPromise.then(() => {
+					events.push('logger.drained');
+				});
+			}
+		};
+		app.logger = mockLogger;
+		Applications[suffix] = app;
+
+		mutableFsPromises.rm = (() => {
+			events.push('fs.rm');
+			return Promise.resolve();
+		}) as typeof fs.promises.rm;
+
+		const deletePromise = invokeDeployDelete({
+			body: { suffix }
+		});
+
+		await new Promise(r => setImmediate(r));
+
+		assert.deepStrictEqual(events, ['proc.kill', 'logger.close']);
+
+		resolveDrain();
+		const { err, response } = await deletePromise;
+
+		assert.strictEqual(err, undefined);
+		assert.strictEqual(response.getStatusCode(), 200);
+		assert.strictEqual(response.getJSON(), 'Deploy Delete Succeed');
+
+		assert.deepStrictEqual(events, [
+			'proc.kill',
+			'logger.close',
+			'logger.drained',
+			'fs.rm'
+		]);
+		assert.strictEqual(Applications[suffix], undefined);
+	});
+});

--- a/src/test/utils.logger.test.ts
+++ b/src/test/utils.logger.test.ts
@@ -1,0 +1,289 @@
+import { strict as assert } from 'assert';
+import { ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import { resolve } from 'path';
+import { PassThrough } from 'stream';
+import { Resource } from '../app';
+import { logProcessOutput, ProcessLogHandle } from '../utils/logger';
+
+type LogProcessOutput = (
+	proc: ChildProcess,
+	resource: Resource
+) => ProcessLogHandle;
+
+type MutableFs = {
+	appendFileSync: typeof fs.appendFileSync;
+	existsSync: typeof fs.existsSync;
+	mkdirSync: typeof fs.mkdirSync;
+};
+
+type MutableFsPromises = {
+	appendFile: typeof fs.promises.appendFile;
+	mkdir: typeof fs.promises.mkdir;
+};
+
+interface MockProcess {
+	proc: ChildProcess;
+	stdout: PassThrough;
+	stderr: PassThrough;
+}
+
+const createLogger = logProcessOutput as unknown as LogProcessOutput;
+const mutableFs = fs as MutableFs;
+const mutableFsPromises = fs.promises as MutableFsPromises;
+const originalAppendFile = mutableFsPromises.appendFile;
+const originalAppendFileSync = mutableFs.appendFileSync;
+const originalConsoleError = console.error;
+const originalConsoleLog = console.log;
+const originalExistsSync = mutableFs.existsSync;
+const originalMkdir = mutableFsPromises.mkdir;
+const originalMkdirSync = mutableFs.mkdirSync;
+const expectedLogFile = resolve(__dirname, '../../logs/app.log');
+
+const resource: Resource = {
+	id: 'logger-lifecycle-test',
+	path: '/deployment/logger-lifecycle-test',
+	jsons: [],
+	runners: []
+};
+
+function createMockProcess(): MockProcess {
+	const stdout = new PassThrough();
+	const stderr = new PassThrough();
+	const proc = Object.assign(new EventEmitter(), {
+		pid: 4242,
+		stdout,
+		stderr
+	}) as unknown as ChildProcess;
+
+	return { proc, stdout, stderr };
+}
+
+function recordPayload(record: string): string {
+	const separator = ` - ${resource.id} | `;
+	const separatorIndex = record.indexOf(separator);
+
+	assert.notStrictEqual(
+		separatorIndex,
+		-1,
+		'log record has deployment prefix'
+	);
+	return record.slice(separatorIndex + separator.length);
+}
+
+async function flushAsyncWork(): Promise<void> {
+	await new Promise<void>(resolveWork => setImmediate(resolveWork));
+}
+
+describe('process logger lifecycle', () => {
+	let append: (record: string) => Promise<void>;
+	let consoleLines: string[];
+	let writePaths: string[];
+	let writes: string[];
+
+	beforeEach(() => {
+		append = () => Promise.resolve();
+		consoleLines = [];
+		writePaths = [];
+		writes = [];
+
+		mutableFsPromises.mkdir = (() =>
+			Promise.resolve(undefined)) as typeof fs.promises.mkdir;
+		mutableFsPromises.appendFile = ((
+			filePath: fs.PathLike,
+			data: string
+		) => {
+			writePaths.push(String(filePath));
+			writes.push(data);
+			return append(data);
+		}) as typeof fs.promises.appendFile;
+		mutableFs.existsSync = () => true;
+		mutableFs.mkdirSync = (() => undefined) as typeof fs.mkdirSync;
+		mutableFs.appendFileSync = ((filePath: fs.PathLike, data: string) => {
+			writePaths.push(String(filePath));
+			writes.push(data);
+		}) as typeof fs.appendFileSync;
+		console.log = (...data: unknown[]) => {
+			consoleLines.push(data.map(String).join(' '));
+		};
+		console.error = () => undefined;
+	});
+
+	afterEach(async () => {
+		for (let iteration = 0; iteration < 4; iteration += 1) {
+			await flushAsyncWork();
+		}
+
+		mutableFsPromises.appendFile = originalAppendFile;
+		mutableFsPromises.mkdir = originalMkdir;
+		mutableFs.appendFileSync = originalAppendFileSync;
+		mutableFs.existsSync = originalExistsSync;
+		mutableFs.mkdirSync = originalMkdirSync;
+		console.error = originalConsoleError;
+		console.log = originalConsoleLog;
+	});
+
+	it('should return a ProcessLogHandle with a close method', async () => {
+		const { proc } = createMockProcess();
+
+		const handle = createLogger(proc, resource);
+
+		assert.strictEqual(typeof handle.close, 'function');
+		assert.ok(handle.close() instanceof Promise);
+		await handle.close();
+	});
+
+	it('should capture and serialize interleaved stdout and stderr writes', async () => {
+		const { proc, stderr, stdout } = createMockProcess();
+		const releases: Array<() => void> = [];
+		let activeWrites = 0;
+		let maximumActiveWrites = 0;
+		append = () => {
+			activeWrites += 1;
+			maximumActiveWrites = Math.max(maximumActiveWrites, activeWrites);
+			return new Promise<void>(resolveWrite => {
+				releases.push(() => {
+					activeWrites -= 1;
+					resolveWrite();
+				});
+			});
+		};
+		const handle = createLogger(proc, resource);
+
+		stdout.write('stdout-first');
+		stderr.write('stderr-second');
+		stdout.write('stdout-third');
+		const closed = handle.close();
+		await flushAsyncWork();
+
+		assert.deepStrictEqual(writes.map(recordPayload), ['stdout-first\n']);
+		releases.shift()?.();
+		await flushAsyncWork();
+		assert.deepStrictEqual(writes.map(recordPayload), [
+			'stdout-first\n',
+			'stderr-second\n'
+		]);
+		releases.shift()?.();
+		await flushAsyncWork();
+		assert.deepStrictEqual(writes.map(recordPayload), [
+			'stdout-first\n',
+			'stderr-second\n',
+			'stdout-third\n'
+		]);
+		releases.shift()?.();
+		await closed;
+
+		assert.strictEqual(maximumActiveWrites, 1);
+		assert.deepStrictEqual(writePaths, [
+			expectedLogFile,
+			expectedLogFile,
+			expectedLogFile
+		]);
+	});
+
+	it('should preserve arbitrary multiline chunks without mangling them', async () => {
+		const { proc, stdout } = createMockProcess();
+		const handle = createLogger(proc, resource);
+		const chunk = 'first line\nsecond line\n\nthird line';
+
+		stdout.write(chunk);
+		await handle.close();
+
+		assert.strictEqual(writes.length, 1);
+		assert.strictEqual(recordPayload(writes[0]), `${chunk}\n`);
+	});
+
+	it('should drain accepted writes before close settles', async () => {
+		const { proc, stdout } = createMockProcess();
+		let releaseWrite: (() => void) | undefined;
+		append = () =>
+			new Promise<void>(resolveWrite => {
+				releaseWrite = resolveWrite;
+			});
+		const handle = createLogger(proc, resource);
+
+		stdout.write('accepted-before-close');
+		let settled = false;
+		const closed = handle.close().then(() => {
+			settled = true;
+		});
+		await flushAsyncWork();
+
+		assert.strictEqual(settled, false);
+		assert.strictEqual(writes.length, 1);
+		assert.ok(releaseWrite);
+		releaseWrite();
+		await closed;
+		assert.strictEqual(settled, true);
+	});
+
+	it('should ignore stream data emitted after close is called', async () => {
+		const { proc, stderr, stdout } = createMockProcess();
+		const handle = createLogger(proc, resource);
+
+		stdout.write('accepted');
+		const closed = handle.close();
+		stdout.write('late-stdout');
+		stderr.write('late-stderr');
+		await closed;
+
+		assert.deepStrictEqual(writes.map(recordPayload), ['accepted\n']);
+		assert.strictEqual(stdout.listenerCount('data'), 0);
+		assert.strictEqual(stderr.listenerCount('data'), 0);
+	});
+
+	it('should return the same drain promise when close is called repeatedly', async () => {
+		const { proc } = createMockProcess();
+		const handle = createLogger(proc, resource);
+
+		const firstClose = handle.close();
+		const secondClose = handle.close();
+
+		assert.strictEqual(secondClose, firstClose);
+		await firstClose;
+	});
+
+	it('should close automatically when the process emits close', async () => {
+		const { proc, stderr, stdout } = createMockProcess();
+		let releaseWrite: (() => void) | undefined;
+		append = () =>
+			new Promise<void>(resolveWrite => {
+				releaseWrite = resolveWrite;
+			});
+		const handle = createLogger(proc, resource);
+
+		stdout.write('accepted');
+		proc.emit('close', 0, null);
+		stdout.write('late-stdout');
+		stderr.write('late-stderr');
+		await flushAsyncWork();
+
+		assert.strictEqual(stdout.listenerCount('data'), 0);
+		assert.strictEqual(stderr.listenerCount('data'), 0);
+		assert.ok(releaseWrite);
+		releaseWrite();
+		await handle.close();
+		assert.deepStrictEqual(writes.map(recordPayload), ['accepted\n']);
+	});
+
+	it('should continue presentation and settle after a disk write fails', async () => {
+		const { proc, stderr, stdout } = createMockProcess();
+		let appendCalls = 0;
+		append = () => {
+			appendCalls += 1;
+			return appendCalls === 1
+				? Promise.reject(new Error('simulated disk failure'))
+				: Promise.resolve();
+		};
+		const handle = createLogger(proc, resource);
+
+		stdout.write('first-message');
+		stderr.write('second-message');
+		await handle.close();
+
+		assert.strictEqual(appendCalls, 2);
+		assert.ok(consoleLines.some(line => line.includes('first-message')));
+		assert.ok(consoleLines.some(line => line.includes('second-message')));
+	});
+});

--- a/src/test/utils.logger.test.ts
+++ b/src/test/utils.logger.test.ts
@@ -2,9 +2,10 @@ import { strict as assert } from 'assert';
 import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import fs from 'fs';
-import { resolve } from 'path';
+import { join } from 'path';
 import { PassThrough } from 'stream';
 import { Resource } from '../app';
+import { logsDirectory } from '../utils/config';
 import { logProcessOutput, ProcessLogHandle } from '../utils/logger';
 
 type LogProcessOutput = (
@@ -39,7 +40,6 @@ const originalConsoleLog = console.log;
 const originalExistsSync = mutableFs.existsSync;
 const originalMkdir = mutableFsPromises.mkdir;
 const originalMkdirSync = mutableFs.mkdirSync;
-const expectedLogFile = resolve(__dirname, '../../logs/app.log');
 
 const resource: Resource = {
 	id: 'logger-lifecycle-test',
@@ -47,6 +47,9 @@ const resource: Resource = {
 	jsons: [],
 	runners: []
 };
+
+const expectedLogDirectory = join(logsDirectory, resource.id);
+const expectedLogFile = join(expectedLogDirectory, 'app.log');
 
 function createMockProcess(): MockProcess {
 	const stdout = new PassThrough();
@@ -61,15 +64,23 @@ function createMockProcess(): MockProcess {
 }
 
 function recordPayload(record: string): string {
-	const separator = ` - ${resource.id} | `;
-	const separatorIndex = record.indexOf(separator);
+	const isoPrefixRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z - /;
 
-	assert.notStrictEqual(
-		separatorIndex,
-		-1,
-		'log record has deployment prefix'
+	assert.ok(
+		isoPrefixRegex.test(record),
+		'log record begins with ISO timestamp and separator'
 	);
-	return record.slice(separatorIndex + separator.length);
+	assert.strictEqual(
+		record.includes(`${resource.id} |`),
+		false,
+		'log record should not contain deployment prefix'
+	);
+	assert.strictEqual(
+		record.includes(resource.id),
+		false,
+		'log record should not contain deployment id'
+	);
+	return record.replace(isoPrefixRegex, '');
 }
 
 async function flushAsyncWork(): Promise<void> {
@@ -79,17 +90,21 @@ async function flushAsyncWork(): Promise<void> {
 describe('process logger lifecycle', () => {
 	let append: (record: string) => Promise<void>;
 	let consoleLines: string[];
+	let mkdirPaths: string[];
 	let writePaths: string[];
 	let writes: string[];
 
 	beforeEach(() => {
 		append = () => Promise.resolve();
 		consoleLines = [];
+		mkdirPaths = [];
 		writePaths = [];
 		writes = [];
 
-		mutableFsPromises.mkdir = (() =>
-			Promise.resolve(undefined)) as typeof fs.promises.mkdir;
+		mutableFsPromises.mkdir = ((targetPath: fs.PathLike) => {
+			mkdirPaths.push(String(targetPath));
+			return Promise.resolve(undefined);
+		}) as typeof fs.promises.mkdir;
 		mutableFsPromises.appendFile = ((
 			filePath: fs.PathLike,
 			data: string
@@ -99,7 +114,10 @@ describe('process logger lifecycle', () => {
 			return append(data);
 		}) as typeof fs.promises.appendFile;
 		mutableFs.existsSync = () => true;
-		mutableFs.mkdirSync = (() => undefined) as typeof fs.mkdirSync;
+		mutableFs.mkdirSync = ((targetPath: fs.PathLike) => {
+			mkdirPaths.push(String(targetPath));
+			return undefined;
+		}) as typeof fs.mkdirSync;
 		mutableFs.appendFileSync = ((filePath: fs.PathLike, data: string) => {
 			writePaths.push(String(filePath));
 			writes.push(data);
@@ -182,6 +200,23 @@ describe('process logger lifecycle', () => {
 		]);
 	});
 
+	it('should format log file content with ISO timestamp and message without deployment ID', async () => {
+		const { proc, stdout } = createMockProcess();
+		const handle = createLogger(proc, resource);
+		const message = 'deterministic-log-entry';
+
+		stdout.write(message);
+		await handle.close();
+
+		assert.strictEqual(writes.length, 1);
+		assert.strictEqual(writePaths[0], expectedLogFile);
+		assert.match(
+			writes[0],
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z - deterministic-log-entry\n$/
+		);
+		assert.strictEqual(writes[0].includes(resource.id), false);
+	});
+
 	it('should preserve arbitrary multiline chunks without mangling them', async () => {
 		const { proc, stdout } = createMockProcess();
 		const handle = createLogger(proc, resource);
@@ -191,6 +226,7 @@ describe('process logger lifecycle', () => {
 		await handle.close();
 
 		assert.strictEqual(writes.length, 1);
+		assert.strictEqual(writePaths[0], expectedLogFile);
 		assert.strictEqual(recordPayload(writes[0]), `${chunk}\n`);
 	});
 
@@ -231,6 +267,35 @@ describe('process logger lifecycle', () => {
 		assert.deepStrictEqual(writes.map(recordPayload), ['accepted\n']);
 		assert.strictEqual(stdout.listenerCount('data'), 0);
 		assert.strictEqual(stderr.listenerCount('data'), 0);
+	});
+
+	it('should not recreate directory when late data arrives after close and directory removal', async () => {
+		const { proc, stderr, stdout } = createMockProcess();
+		const handle = createLogger(proc, resource);
+
+		stdout.write('accepted-data');
+		await handle.close();
+
+		assert.strictEqual(writes.length, 1);
+		assert.ok(mkdirPaths.includes(expectedLogDirectory));
+
+		const mkdirCountAfterClose = mkdirPaths.length;
+		const writesCountAfterClose = writes.length;
+
+		stdout.write('late-stdout-after-delete');
+		stderr.write('late-stderr-after-delete');
+		await flushAsyncWork();
+
+		assert.strictEqual(
+			mkdirPaths.length,
+			mkdirCountAfterClose,
+			'mkdir should not be called after close'
+		);
+		assert.strictEqual(
+			writes.length,
+			writesCountAfterClose,
+			'no additional writes should occur after close'
+		);
 	});
 
 	it('should return the same drain promise when close is called repeatedly', async () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,3 +21,4 @@ export const configDir = (name: string): string => {
 export const basePath = configDir(join('metacall', 'faas'));
 
 export const appsDirectory = join(basePath, 'apps');
+export const logsDirectory = join(basePath, 'logs');

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -29,20 +29,26 @@ export const deployProcess = async (
 		}
 	}
 
+	const application = Applications[resource.id];
+	if (!application) {
+		throw new Error(`Application '${resource.id}' is not registered`);
+	}
+
 	const proc = spawn('metacall', [desiredPath], {
 		stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 		cwd: resource.path, // Current working directory resolution
 		env: envStringified // Environment variable injection
 	});
 
+	// Attach logger before sending load message so no early output is missed
+	const logger = logProcessOutput(proc, resource);
+	application.logger = logger;
+
 	// Send load message with the deploy information
 	proc.send({
 		type: WorkerMessageType.Load,
 		data: resource
 	});
-
-	// Pipe the stdout and stderr to the logger
-	logProcessOutput(proc, resource.id);
 
 	// Wait for load result
 	let deployResolve: (value: void) => void;
@@ -60,8 +66,17 @@ export const deployProcess = async (
 	proc.on('message', (payload: WorkerMessageUnknown) => {
 		switch (payload.type) {
 			case WorkerMessageType.MetaData: {
+				if (Applications[resource.id] !== application) {
+					proc.kill();
+					void logger.close();
+					return deployReject(
+						new Error(
+							`Application '${resource.id}' changed during deployment`
+						)
+					);
+				}
+
 				// Get the deploy data and store the process and app into our tables
-				const application = Applications[resource.id];
 				const deployment = payload.data as Deployment;
 
 				application.proc = proc;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,12 +1,7 @@
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-
-interface LogMessage {
-	deploymentName: string;
-	workerPID: number;
-	message: string;
-}
+import { Resource } from '../app';
 
 // Shuffle the array randomly on startup (equal randomness is not relevant that's why we use this sort trick)
 const ANSICode: number[] = [
@@ -27,14 +22,6 @@ const logFilePath = path.join(__dirname, '../../logs/');
 const logFileName = 'app.log';
 const logFileFullPath = path.resolve(path.join(logFilePath, logFileName));
 
-// TODO: Implement this properly?
-// const maxWorkerWidth = (maxIndexWidth = 3): number => {
-// 	const workerLengths = Object.keys(Applications).map(
-// 		worker => worker.length
-// 	);
-// 	return Math.max(...workerLengths) + maxIndexWidth;
-// };
-
 const assignColorToWorker = (
 	deploymentName: string,
 	workerPID: number
@@ -48,53 +35,85 @@ const assignColorToWorker = (
 	return `\x1b[38;5;${assignColorCode}m${deploymentName}\x1b[0m`;
 };
 
-class Logger {
-	private logQueue: LogMessage[] = [];
-	private isProcessing = false;
+export interface ProcessLogHandle {
+	close(): Promise<void>;
+}
 
-	private async processQueue(): Promise<void> {
-		if (this.isProcessing || this.logQueue.length === 0) return;
-		this.isProcessing = true;
+class DeploymentLogger implements ProcessLogHandle {
+	private tail: Promise<void> = Promise.resolve();
+	private accepting = true;
+	private closePromise?: Promise<void>;
 
-		while (this.logQueue.length > 0) {
-			const logEntry = this.logQueue.shift();
-			if (logEntry) {
-				const { deploymentName, workerPID, message } = logEntry;
-				this.store(deploymentName, message);
-				this.present(deploymentName, workerPID, message);
-				await new Promise(resolve => setTimeout(resolve, 0));
-			}
+	private readonly proc: ChildProcess;
+	private readonly resource: Resource;
+	private readonly onStdoutData: (data: Buffer) => void;
+	private readonly onStderrData: (data: Buffer) => void;
+	private readonly onProcessClose: () => void;
+
+	constructor(proc: ChildProcess, resource: Resource) {
+		this.proc = proc;
+		this.resource = resource;
+
+		this.onStdoutData = (data: Buffer) => {
+			this.enqueue(data.toString());
+		};
+		this.onStderrData = (data: Buffer) => {
+			this.enqueue(data.toString());
+		};
+		this.onProcessClose = () => {
+			void this.close();
+		};
+
+		this.proc.stdout?.on('data', this.onStdoutData);
+		this.proc.stderr?.on('data', this.onStderrData);
+		this.proc.on('close', this.onProcessClose);
+	}
+
+	private enqueue(message: string): void {
+		if (!this.accepting) {
+			return;
 		}
 
-		this.isProcessing = false;
+		this.tail = this.tail.then(async () => {
+			await this.store(message);
+			this.present(message);
+		});
 	}
 
-	public enqueueLog(
-		deploymentName: string,
-		workerPID: number,
-		message: string
-	): void {
-		this.logQueue.push({ deploymentName, workerPID, message });
-		this.processQueue().catch(console.error);
+	public close(): Promise<void> {
+		if (!this.closePromise) {
+			this.accepting = false;
+			this.detachListeners();
+			this.closePromise = this.tail;
+		}
+		return this.closePromise;
 	}
 
-	private store(deploymentName: string, message: string): void {
+	private detachListeners(): void {
+		this.proc.stdout?.off('data', this.onStdoutData);
+		this.proc.stderr?.off('data', this.onStderrData);
+		this.proc.off('close', this.onProcessClose);
+	}
+
+	private async store(message: string): Promise<void> {
 		const timeStamp = new Date().toISOString();
-		const logMessage = `${timeStamp} - ${deploymentName} | ${message}\n`;
+		const logMessage = `${timeStamp} - ${this.resource.id} | ${message}\n`;
 
-		if (!fs.existsSync(logFilePath)) {
-			fs.mkdirSync(logFilePath, { recursive: true });
+		try {
+			await fs.promises.mkdir(logFilePath, { recursive: true });
+			await fs.promises.appendFile(logFileFullPath, logMessage, {
+				encoding: 'utf-8'
+			});
+		} catch (err) {
+			console.error(err);
 		}
-		fs.appendFileSync(logFileFullPath, logMessage, { encoding: 'utf-8' });
 	}
 
-	private present(
-		deploymentName: string,
-		workerPID: number,
-		message: string
-	): void {
+	private present(message: string): void {
 		message = message.trim();
 		const fixedWidth = 24;
+		const deploymentName = this.resource.id;
+		const workerPID = this.proc.pid || 0;
 
 		let paddedName = deploymentName.padEnd(fixedWidth, ' ');
 		if (deploymentName.length > fixedWidth) {
@@ -113,16 +132,9 @@ class Logger {
 	}
 }
 
-const logger = new Logger();
-
 export function logProcessOutput(
 	proc: ChildProcess,
-	deploymentName: string
-): void {
-	proc.stdout?.on('data', (data: Buffer) => {
-		logger.enqueueLog(deploymentName, proc.pid || 0, data.toString());
-	});
-	proc.stderr?.on('data', (data: Buffer) => {
-		logger.enqueueLog(deploymentName, proc.pid || 0, data.toString());
-	});
+	resource: Resource
+): ProcessLogHandle {
+	return new DeploymentLogger(proc, resource);
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Resource } from '../app';
+import { logsDirectory } from './config';
 
 // Shuffle the array randomly on startup (equal randomness is not relevant that's why we use this sort trick)
 const ANSICode: number[] = [
@@ -17,10 +18,6 @@ const PIDToColorCodeMap: PIDToColorCodeMapType = {};
 
 // Counter for color assignment
 let colorIndex = 0;
-
-const logFilePath = path.join(__dirname, '../../logs/');
-const logFileName = 'app.log';
-const logFileFullPath = path.resolve(path.join(logFilePath, logFileName));
 
 const assignColorToWorker = (
 	deploymentName: string,
@@ -46,6 +43,8 @@ class DeploymentLogger implements ProcessLogHandle {
 
 	private readonly proc: ChildProcess;
 	private readonly resource: Resource;
+	private readonly logDirectory: string;
+	private readonly logFile: string;
 	private readonly onStdoutData: (data: Buffer) => void;
 	private readonly onStderrData: (data: Buffer) => void;
 	private readonly onProcessClose: () => void;
@@ -53,6 +52,8 @@ class DeploymentLogger implements ProcessLogHandle {
 	constructor(proc: ChildProcess, resource: Resource) {
 		this.proc = proc;
 		this.resource = resource;
+		this.logDirectory = path.join(logsDirectory, resource.id);
+		this.logFile = path.join(this.logDirectory, 'app.log');
 
 		this.onStdoutData = (data: Buffer) => {
 			this.enqueue(data.toString());
@@ -97,11 +98,11 @@ class DeploymentLogger implements ProcessLogHandle {
 
 	private async store(message: string): Promise<void> {
 		const timeStamp = new Date().toISOString();
-		const logMessage = `${timeStamp} - ${this.resource.id} | ${message}\n`;
+		const logMessage = `${timeStamp} - ${message}\n`;
 
 		try {
-			await fs.promises.mkdir(logFilePath, { recursive: true });
-			await fs.promises.appendFile(logFileFullPath, logMessage, {
+			await fs.promises.mkdir(this.logDirectory, { recursive: true });
+			await fs.promises.appendFile(this.logFile, logMessage, {
 				encoding: 'utf-8'
 			});
 		} catch (err) {


### PR DESCRIPTION
## Summary
Migrate log storage from a single `logs/app.log` file to deployment-local paths at `~/.metacall/faas/logs/<deployment-suffix>/app.log`. Each deployment now gets its own directory and log file, with the redundant deployment ID prefix removed from file content (since the path already encodes identity).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Chore / CI
- [ ] Breaking change

## How to test
Steps to reproduce or verify the change locally:
1. Checkout the branch
2. Run `npm ci` (or equivalent)
3. Run `npm test` and any additional verification steps

## Checklist
- [x] I have read the contributing guidelines
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I updated documentation if necessary

## Notes for reviewers
-   **From global to per-deployment logging**: Previously all deployments wrote to a single `logs/app.log` with a `${deploymentId} |` prefix to distinguish sources. Now each deployment gets its own directory and file at `logs/<suffix>/app.log`. The path itself encodes identity, making the inline prefix redundant.
-   **Clean teardown**: Since each deployment's logs are isolated to their own directory, deleting a deployment can cleanly remove its logs without affecting other deployments.
-   **Console vs disk format**: Console output retains the colored `${deploymentName} |` prefix for readability. Only the on-disk format was simplified to `${ISO} ${message}\n` since the file path already identifies the source.
